### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     version=read_package_variable('__version__'),
     description='BBN D3M primitives',
     author='BBN',
+    license='MIT',
     #packages=['d3m-bbn-primitives', 'd3m-bbn-primitives.bbn_primitives.time_series'],
     #packages=find_packages('time_series'),
     packages=find_packages(exclude=['examples', 'notebooks', 'pipelines', 'annotations', 'tools']),


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.